### PR TITLE
Update PowerZure.ps1

### DIFF
--- a/PowerZure.ps1
+++ b/PowerZure.ps1
@@ -154,7 +154,7 @@ Write-Host @'
 		        $obj = New-Object -TypeName psobject
 		        $username = $APSUser.Account
 		        $user = Invoke-RestMethod -Headers $Headers -Uri 'https://graph.microsoft.com/beta/me'
-		        $userid=$user.userprincipalname
+		        $userid=$user.Id
 		        $rbacroles = Get-AzRoleAssignment -ObjectId $userid *>&1
 		        $obj | Add-Member -MemberType NoteProperty -Name Username -Value $user.userPrincipalName
 		        $obj | Add-Member -MemberType NoteProperty -Name objectId -Value $userId


### PR DESCRIPTION
In line 158, we have below.
 $userid=$user.userprincipalname
which is probably intended to get the Id of the username, not the principal name.
As a result below line :
$rbacroles = Get-AzRoleAssignment -ObjectId $userid *>&1

Shows the below error 
The Principal ID <userprincipalName> is not valid. Principal ID must be a GUID.

**Proposed fix:**
Change this : 
 $userid=$user.userprincipalname
to this to get the Id:
 $userid=$user.Id