### PR TITLE
Updated endpoint and body for Add-AzureADRole

### DIFF
--- a/PowerZure.psm1
+++ b/PowerZure.psm1
@@ -531,12 +531,13 @@ function Add-AzureADRole
     }
 
     $body = [PSCustomObject]@{
+            "@odata.type" = "#microsoft.graph.unifiedRoleAssignment"
             roleDefinitionId = $roleid
             principalId = $userid
             directoryScopeId = '/'
             }
     $json = $body | convertto-json
-    Invoke-RestMethod -Headers $Headers -ContentType 'application/json' -Method POST -Body $json -Uri https://graph.microsoft.com/beta/roleManagement/entitlementManagement/roleAssignment  
+    Invoke-RestMethod -Headers $Headers -ContentType 'application/json' -Method POST -Body $json -Uri https://graph.microsoft.com/v1.0/roleManagement/directory/roleAssignments  
 }
 
 function Get-AzureTarget


### PR DESCRIPTION
Went to use Add-AzureADRole and was getting a `bad request` response:
![BadReq](https://github.com/hausec/PowerZure/assets/25848582/7ad85f8a-c6b4-4793-adac-83f4092c6b8d)

Looks like the endpoint might have been [updated](https://learn.microsoft.com/en-us/graph/api/rbacapplication-post-roleassignments?view=graph-rest-1.0&tabs=http#http-request), also seems to need the data type `unifiedRoleAssignment` specified.